### PR TITLE
Remove unused LogicalScanNodeTable's properties

### DIFF
--- a/src/include/optimizer/projection_push_down_optimizer.h
+++ b/src/include/optimizer/projection_push_down_optimizer.h
@@ -46,6 +46,7 @@ private:
     void visitMerge(planner::LogicalOperator* op) override;
     void visitCopyFrom(planner::LogicalOperator* op) override;
     void visitTableFunctionCall(planner::LogicalOperator*) override;
+    void visitScanNodeTable(planner::LogicalOperator*) override;
 
     void visitSetInfo(const binder::BoundSetPropertyInfo& info);
     void visitInsertInfo(const planner::LogicalInsertInfo& info);
@@ -56,6 +57,8 @@ private:
 
     void preAppendProjection(planner::LogicalOperator* op, common::idx_t childIdx,
         binder::expression_vector expressions);
+
+    bool clearScanNodeTableProperties(planner::LogicalOperator* op) const;
 
 private:
     binder::expression_set propertiesInUse;

--- a/src/include/planner/operator/scan/logical_scan_node_table.h
+++ b/src/include/planner/operator/scan/logical_scan_node_table.h
@@ -77,6 +77,7 @@ public:
     std::shared_ptr<binder::Expression> getNodeID() const { return nodeID; }
     std::vector<common::table_id_t> getTableIDs() const { return nodeTableIDs; }
 
+    void clearProperty() { properties.clear(); }
     binder::expression_vector getProperties() const { return properties; }
     void addProperty(std::shared_ptr<binder::Expression> expr) {
         properties.push_back(std::move(expr));

--- a/src/processor/operator/scan/primary_key_scan_node_table.cpp
+++ b/src/processor/operator/scan/primary_key_scan_node_table.cpp
@@ -16,9 +16,10 @@ std::string PrimaryKeyScanPrintInfo::toString() const {
         result += ",Alias: ";
         result += alias;
     }
-    result += ", Expressions: ";
-    result += binder::ExpressionUtil::toString(expressions);
-
+    if (!expressions.empty()) {
+        result += ", Expressions: ";
+        result += binder::ExpressionUtil::toString(expressions);
+    }
     return result;
 }
 
@@ -36,8 +37,18 @@ void PrimaryKeyScanNodeTable::initLocalStateInternal(ResultSet* resultSet,
     for (auto& pos : info.outVectorsPos) {
         outVectors.push_back(resultSet->getValueVector(pos).get());
     }
-    scanState = std::make_unique<NodeTableScanState>(
-        resultSet->getValueVector(info.nodeIDPos).get(), outVectors, outVectors[0]->state);
+    if (outVectors.empty()) {
+
+        scanState =
+            std::make_unique<NodeTableScanState>(resultSet->getValueVector(info.nodeIDPos).get(),
+                outVectors, DataChunkState::getSingleValueDataChunkState());
+
+        ;
+    } else {
+
+        scanState = std::make_unique<NodeTableScanState>(
+            resultSet->getValueVector(info.nodeIDPos).get(), outVectors, outVectors[0]->state);
+    }
     indexEvaluator->init(*resultSet, context->clientContext);
 }
 


### PR DESCRIPTION
# Description

* Remove unused scanNodeTable properties,while filter be push into scanNodeTable
* Remove unnecessary projection upon scanNodeTable


# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).